### PR TITLE
all: fix build

### DIFF
--- a/ini/ini.go
+++ b/ini/ini.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jteeuwen/ini"
 	"github.com/karlek/nyfiken/page"
 	"github.com/karlek/nyfiken/settings"
+	"github.com/mewbak/ini"
 	"github.com/mewkiz/pkg/errutil"
 )
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -127,66 +127,42 @@ func initialize() (err error) {
 	}
 
 	// Create a nyfiken config folder if it doesn't exist.
-	found, err := osutil.Exists(NyfikenRoot)
-	if err != nil {
-		return errutil.Err(err)
-	}
-	if !found {
+	if !osutil.Exists(NyfikenRoot) {
 		err := os.Mkdir(NyfikenRoot, DefaultFolderPerms)
 		if err != nil {
 			return errutil.Err(err)
 		}
 	}
 
-	found, err = osutil.Exists(CacheRoot)
-	if err != nil {
-		return errutil.Err(err)
-	}
-	if !found {
+	if !osutil.Exists(CacheRoot) {
 		err := os.Mkdir(CacheRoot, DefaultFolderPerms)
 		if err != nil {
 			return errutil.Err(err)
 		}
 	}
 
-	found, err = osutil.Exists(ReadRoot)
-	if err != nil {
-		return errutil.Err(err)
-	}
-	if !found {
+	if !osutil.Exists(ReadRoot) {
 		err := os.Mkdir(ReadRoot, DefaultFolderPerms)
 		if err != nil {
 			return errutil.Err(err)
 		}
 	}
 
-	found, err = osutil.Exists(DebugRoot)
-	if err != nil {
-		return errutil.Err(err)
-	}
-	if !found {
+	if !osutil.Exists(DebugRoot) {
 		err := os.Mkdir(DebugRoot, DefaultFolderPerms)
 		if err != nil {
 			return errutil.Err(err)
 		}
 	}
 
-	found, err = osutil.Exists(DebugCacheRoot)
-	if err != nil {
-		return errutil.Err(err)
-	}
-	if !found {
+	if !osutil.Exists(DebugCacheRoot) {
 		err := os.Mkdir(DebugCacheRoot, DefaultFolderPerms)
 		if err != nil {
 			return errutil.Err(err)
 		}
 	}
 
-	found, err = osutil.Exists(DebugReadRoot)
-	if err != nil {
-		return errutil.Err(err)
-	}
-	if !found {
+	if !osutil.Exists(DebugReadRoot) {
 		err := os.Mkdir(DebugReadRoot, DefaultFolderPerms)
 		if err != nil {
 			return errutil.Err(err)


### PR DESCRIPTION
Update osutil.Exists usage, the signature of which has been
refined to `Exists(path string) bool`. osutil.Exists panics
in case the os.Stat call fails, a very rare case. Happens
only when there is a harddrive error?

Sometimes being a packrat is good. The ini library at
https://github.com/jteeuwen/ini has disappeared. A clone of
the repo is available at https://github.com/mewbak/ini

Import mewbak/ini for now.